### PR TITLE
DiscreteGroundWater hash and equals methods out of date

### DIFF
--- a/src/main/java/gov/usgs/wma/waterdata/DiscreteGroundWater.java
+++ b/src/main/java/gov/usgs/wma/waterdata/DiscreteGroundWater.java
@@ -315,6 +315,7 @@ public class DiscreteGroundWater {
 				java.util.Objects.equals(locationIdentifier, that.locationIdentifier) &&
 				java.util.Objects.equals(agencyCode, that.agencyCode) &&
 				java.util.Objects.equals(dateTimeAccuracyCode, that.dateTimeAccuracyCode) &&
+				java.util.Objects.equals(dateTimeAccuracy, that.dateTimeAccuracy) &&
 				java.util.Objects.equals(startTime, that.startTime) &&
 				java.util.Objects.equals(endTime, that.endTime) &&
 				java.util.Objects.equals(party, that.party) &&
@@ -351,6 +352,7 @@ public class DiscreteGroundWater {
 				locationIdentifier,
 				agencyCode,
 				dateTimeAccuracyCode,
+				dateTimeAccuracy,
 				startTime,
 				endTime,
 				party,

--- a/src/main/java/gov/usgs/wma/waterdata/DiscreteGroundWater.java
+++ b/src/main/java/gov/usgs/wma/waterdata/DiscreteGroundWater.java
@@ -314,6 +314,7 @@ public class DiscreteGroundWater {
 		return java.util.Objects.equals(fieldVisitIdentifier, that.fieldVisitIdentifier) &&
 				java.util.Objects.equals(locationIdentifier, that.locationIdentifier) &&
 				java.util.Objects.equals(agencyCode, that.agencyCode) &&
+				java.util.Objects.equals(dateTimeAccuracyCode, that.dateTimeAccuracyCode) &&
 				java.util.Objects.equals(startTime, that.startTime) &&
 				java.util.Objects.equals(endTime, that.endTime) &&
 				java.util.Objects.equals(party, that.party) &&
@@ -349,6 +350,7 @@ public class DiscreteGroundWater {
 				fieldVisitIdentifier,
 				locationIdentifier,
 				agencyCode,
+				dateTimeAccuracyCode,
 				startTime,
 				endTime,
 				party,


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Small issues w/ the hash and equals methods of DiscreteGroundWater

Description
-----------
Two fields were forgotten in the hash and equals methods of DiscreteGroundWater

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
